### PR TITLE
Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/sparrow-similarity/sparrow-similiarity/pom.xml
+++ b/sparrow-similarity/sparrow-similiarity/pom.xml
@@ -117,12 +117,12 @@
 		<repository>
 			<id>maven.aksw.internal</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/archiva/repository/internal</url>
+			<url>https://maven.aksw.org/archiva/repository/internal</url>
 		</repository>
 		<repository>
 			<id>maven.aksw.snapshots</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/archiva/repository/snapshots</url>
+			<url>https://maven.aksw.org/archiva/repository/snapshots</url>
 		</repository>
 
 	</repositories>


### PR DESCRIPTION
Resolve dependencies from the AKSW repository over https.